### PR TITLE
Remove stray whitespace character

### DIFF
--- a/episodes/intro_data_set.Rmd
+++ b/episodes/intro_data_set.Rmd
@@ -1,4 +1,4 @@
- ---
+---
 title: "Introduction to the Data Set"
 teaching: 30
 exercises: 5


### PR DESCRIPTION
I think this space character at the start of the opening `---` line of the episode source file has been causing your lesson builds to fail.